### PR TITLE
handle proxy errors (&log to stderr)

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,10 @@ config.authErrorMessage = config.authErrorMessage || 'Authorize yourself at anro
 
 var proxy = httpProxy.createProxyServer({})
 
+proxy.on('error', function (err) {
+  console.error(err)
+})
+
 var server = http.createServer(function (req, res) {
   if (config.whitelist) {
     var path = req.url


### PR DESCRIPTION
accessing whitelisted path when upstream is not reachable led to auth-proxy exiting with an error.

prevent exception by handling the error ourselves