### PR TITLE
Support Gruppe Adler SSO authentication

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -27,9 +27,13 @@ function fetchUser (token, cb) {
   }, function (err, resp, body) {
     if (err) {
       cb(err)
+    } else if (body && body.errors) {
+      console.error('GraphQL error:', body.errors)
+      cb(new Error('GraphQL request failed'))
     } else if (body && body.data && body.data.authenticate) {
       cb(null, body.data.authenticate)
     } else {
+      console.error('Authentication failed: not authenticated')
       cb(new Error('Not authenticated'))
     }
   })


### PR DESCRIPTION
## Summary
- Use GraphQL `authenticate` mutation (POST) instead of REST GET to validate users against `sso.gruppe-adler.de`
- Check `group.tag` instead of `group.name` to match the SSO's data model
- Extract user from `body.data.authenticate` response structure

## Config changes needed
The `config.js` must be updated to point to the SSO (not included in this PR since it's environment-specific):
```js
module.exports = {
  cookie: 'gruppe-adler-sso-token',
  group: 'adler',
  userUrl: 'https://sso.gruppe-adler.de/api/v1/graphql',
  // ...
}
```

## Test plan
- [ ] Set `config.js` with SSO settings (`cookie`, `group`, `userUrl`)
- [ ] Verify authenticated user with "Adler" group gets proxied through
- [ ] Verify unauthenticated requests are rejected
- [ ] Verify users without "Adler" group are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)